### PR TITLE
Ignore automatically generated MYMETA files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Makefile.bak
 pm_to_blib
 blib
 .git
+MYMETA*


### PR DESCRIPTION
This ensures that the working copy is still clean, even after running `perl
Makefile.PL`.