### PR TITLE
Update META.yml

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -1,13 +1,26 @@
-# http://module-build.sourceforge.net/META-spec.html
-#XXXXXXX This is a prototype!!!  It will change in the future!!! XXXXX#
-name:         Device-Gsm
-version:      1.57
-version_from: Gsm.pm
-installdirs:  site
+---
+abstract: 'Perl extension to interface GSM phones / modems'
+author:
+  - 'Cosimo Streppone <cosimo@cpan.org>, Grzegorz WoÅºniak <wozniakg@gmail.com>'
+build_requires:
+  ExtUtils::MakeMaker: '0'
+configure_requires:
+  ExtUtils::MakeMaker: '0'
+dynamic_config: 0
+generated_by: 'ExtUtils::MakeMaker version 7.0401, CPAN::Meta::Converter version 2.150001'
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Device-Gsm
+no_index:
+  directory:
+    - t
+    - inc
 requires:
-    Device::Modem:                 1.47
-    Device::SerialPort:            0
-    Test::More:                    0
-
-distribution_type: module
-generated_by: ExtUtils::MakeMaker version 6.17
+  Device::Modem: '1.47'
+  Device::SerialPort: '0'
+  Test::More: '0'
+resources:
+  repository: git://github.com/cosimo/perl5-device-gsm.git
+version: '1.60'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use 5.008;
 use ExtUtils::MakeMaker;
 WriteMakefile(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use 5.008;
 use ExtUtils::MakeMaker;
 WriteMakefile(
     'ABSTRACT_FROM' => 'lib/Device/Gsm.pm',
-    'AUTHOR'        => 'Cosimo Streppone <cosimo@cpan.org>,Grzegorz Woźniak <wozniakg@gmail.com>',
+    'AUTHOR'        => 'Cosimo Streppone <cosimo@cpan.org>, Grzegorz Woźniak <wozniakg@gmail.com>',
     'NAME'          => 'Device::Gsm',
     'VERSION_FROM'  => 'lib/Device/Gsm.pm', # finds $VERSION
     'PREREQ_PM'     => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,11 +16,11 @@ WriteMakefile(
             : ( 'Device::SerialPort'=> 0 )
         )
     },
+    'LICENSE' => 'perl',
     'META_MERGE' => {
         resources => {
             repository => 'git://github.com/cosimo/perl5-device-gsm.git',
             bugtracker => 'mailto:bug-device-gsm@rt.cpan.org',
-            license    => 'http://dev.perl.org/licenses/',
         },
     },
 );


### PR DESCRIPTION
`META.yml` now conforms to the current `META.yml` specification.  These changes solve the non-conformant `META.yml` spec issue on http://cpants.cpanauthors.org/dist/Device-Gsm.