### PR TITLE
Remove the svn $Id$ tag

### DIFF
--- a/bin/autoscan
+++ b/bin/autoscan
@@ -7,8 +7,6 @@
 # cosimo@cpan.org with subject "Device::Gsm profile"
 #
 # Usage: autoscan --device=/dev/ttyS0 --baud=19200 --file=my_device.log
-#
-# $Id: autoscan,v 1.4 2004-01-10 21:33:46 cosimo Exp $
 
 use Device::Gsm;
 use Getopt::Long;

--- a/contrib/Modem__Hayes.pl
+++ b/contrib/Modem__Hayes.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/perl -w
 
-# $Id: Modem__Hayes.pl,v 1.1 2003-03-23 08:14:32 cosimo Exp $
-
 use Device::SerialPort qw(:STAT 0.07);
 use strict;
 

--- a/examples/delete_message.pl
+++ b/examples/delete_message.pl
@@ -8,7 +8,7 @@ use lib '../lib';
 use lib '../';
 use Gsm;
 
-print "\nthis is ", '$Id: delete_message.pl,v 1.3 2006-04-20 20:06:15 cosimo Exp $', "\n";
+print "\nthis is delete_message.pl\n";
 print "\nDeletes one sms message from your sim card...\n";
 
 my $port = $ENV{'DEV_GSM_PORT'} || ( $^O =~ /Win/ ? 'COM2' : '/dev/ttyS1' );

--- a/examples/delete_message.pl
+++ b/examples/delete_message.pl
@@ -2,8 +2,6 @@
 #
 # Short example of use for Device::Gsm class
 # Script that deletes permanently one message from sim
-#
-# $Id: delete_message.pl,v 1.3 2006-04-20 20:06:15 cosimo Exp $
 
 use strict;
 use lib '../lib';

--- a/examples/get_time.pl
+++ b/examples/get_time.pl
@@ -2,8 +2,6 @@
 #
 # Short example of use for Device::Gsm class
 # Get date and time from phone 
-#
-# $Id: get_time.pl,v 1.1 2003-12-15 22:49:44 cosimo Exp $
 
 use strict;
 use lib 'blib/arch';

--- a/examples/get_time.pl
+++ b/examples/get_time.pl
@@ -8,7 +8,7 @@ use lib 'blib/arch';
 use lib 'blib';
 use Device::Gsm;
 
-print "\nthis is ", '$Id: get_time.pl,v 1.1 2003-12-15 22:49:44 cosimo Exp $', "\n";
+print "\nthis is get_time.pl\n";
 print "This script tries to get your gsm date/time\n";
 
 my $gsm = conn();

--- a/examples/network.pl
+++ b/examples/network.pl
@@ -1,8 +1,6 @@
 #!/usr/bin/perl
 #
 # Get GSM network name 
-#
-# $Id: network.pl,v 1.1 2006-12-19 21:04:52 cosimo Exp $
 
 use strict;
 use Device::Gsm;

--- a/examples/read_messages.pl
+++ b/examples/read_messages.pl
@@ -8,7 +8,7 @@ use lib '../lib';
 use lib '../';
 use Gsm;
 
-print "\nthis is ", '$Id: read_messages.pl,v 1.5 2006-04-20 20:05:45 cosimo Exp $', "\n";
+print "\nthis is read_messages.pl\n";
 print "\nTrying to read all messages you have on your SIM card...\n";
 
 my $port = $ENV{'DEV_GSM_PORT'} || ( $^O =~ /Win/ ? 'COM2' : '/dev/ttyS1' );

--- a/examples/read_messages.pl
+++ b/examples/read_messages.pl
@@ -2,8 +2,6 @@
 #
 # Short example of use for Device::Gsm class
 # Script that reads all SMS stored on SIM
-#
-# $Id: read_messages.pl,v 1.5 2006-04-20 20:05:45 cosimo Exp $
 
 use strict;
 use lib '../lib';

--- a/examples/report_signal.pl
+++ b/examples/report_signal.pl
@@ -2,8 +2,6 @@
 #
 # Short example of use for Device::Gsm class
 # Report signal quality of mobile phone line
-#
-# $Id: report_signal.pl,v 1.2 2004-03-15 21:43:22 cosimo Exp $
 
 use strict;
 use Device::Gsm;

--- a/examples/report_signal.pl
+++ b/examples/report_signal.pl
@@ -6,7 +6,7 @@
 use strict;
 use Device::Gsm;
 
-print "\nthis is ", '$Id: report_signal.pl,v 1.2 2004-03-15 21:43:22 cosimo Exp $', "\n";
+print "\nthis is report_signal.pl\n";
 print "\nGetting signal quality of your mobile phone line...\n\n";
 
 my $port = $ENV{DEV_GSM_PORT} || ($^O =~ /Win/ ? 'COM2' : '/dev/ttyS1');

--- a/examples/send_sms.pl
+++ b/examples/send_sms.pl
@@ -1,8 +1,6 @@
 #!/usr/bin/perl
 #
 # Short example of use for Device::Gsm class
-#
-# $Id: send_sms.pl,v 1.2 2002-04-29 17:03:46 cosimo Exp $
 
 use strict;
 use Device::Gsm;

--- a/examples/send_sms.pl
+++ b/examples/send_sms.pl
@@ -5,7 +5,7 @@
 use strict;
 use Device::Gsm;
 
-print "\nthis is ", '$Id: send_sms.pl,v 1.2 2002-04-29 17:03:46 cosimo Exp $', "\n";
+print "\nthis is send_sms.pl\n";
 print "I hope I can send an SMS on your GSM phone attached to...\n";
 
 my $port = $^O =~ /Win/ ? 'COM2' : '/dev/ttyS1';

--- a/examples/send_to_cosimo.pl
+++ b/examples/send_to_cosimo.pl
@@ -5,8 +5,6 @@
 #
 # This is a funny experiment to know how many people are
 # using this module out there... :-) 
-#
-# $Id: send_to_cosimo.pl,v 1.5 2006-05-01 11:56:54 cosimo Exp $
 
 use strict;
 use Config;

--- a/examples/send_to_cosimo.pl
+++ b/examples/send_to_cosimo.pl
@@ -10,7 +10,7 @@ use strict;
 use Config;
 use Device::Gsm;
 
-print "\nthis is ", '$Id: send_to_cosimo.pl,v 1.5 2006-05-01 11:56:54 cosimo Exp $', "\n\n";
+print "\nthis is send_to_cosimo.pl\n\n";
 print "\n", '-' x 80, "\n";
 print "HEY! I'm sending out an SMS message to the author of Device::Gsm module\n";
 print "(Cosimo Streppone <cosimo\@cpan.org>).\n\n";

--- a/examples/sync_time.pl
+++ b/examples/sync_time.pl
@@ -8,7 +8,7 @@ use lib 'blib/arch';
 use lib 'blib';
 use Device::Gsm;
 
-print "\nthis is ", '$Id: sync_time.pl,v 1.2 2003-12-15 22:50:12 cosimo Exp $', "\n";
+print "\nthis is sync_time.pl\n";
 print "This script tries to set phone date/time to that of your PC clock\n";
 
 my $gsm = conn();

--- a/examples/sync_time.pl
+++ b/examples/sync_time.pl
@@ -2,8 +2,6 @@
 #
 # Short example of use for Device::Gsm class
 # Get date and time from phone 
-#
-# $Id: sync_time.pl,v 1.2 2003-12-15 22:50:12 cosimo Exp $
 
 use strict;
 use lib 'blib/arch';

--- a/lib/Device/Gsm/Charset.pm
+++ b/lib/Device/Gsm/Charset.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Device::Gsm::Charset;
 $VERSION = substr q$Revision$, 0, 10;

--- a/lib/Device/Gsm/Pdu.pm
+++ b/lib/Device/Gsm/Pdu.pm
@@ -12,8 +12,6 @@
 #
 # Commercial support is available. Write me if you are
 # interested in new features or software support.
-#
-# $Id$
 
 # TODO document decode_text8()
 

--- a/lib/Device/Gsm/Sms.pm
+++ b/lib/Device/Gsm/Sms.pm
@@ -12,8 +12,6 @@
 #
 # Commercial support is available. Write me if you are
 # interested in new features or software support.
-#
-# $Id$
 
 package Device::Gsm::Sms;
 

--- a/lib/Device/Gsm/Sms/Structure.pm
+++ b/lib/Device/Gsm/Sms/Structure.pm
@@ -9,8 +9,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Device::Gsm::Sms;
 

--- a/lib/Device/Gsm/Sms/Token.pm
+++ b/lib/Device/Gsm/Sms/Token.pm
@@ -11,8 +11,6 @@
 #
 # Commercial support is available. Write me if you are
 # interested in new features or software support.
-#
-# $Id$
 
 package Sms::Token;
 

--- a/lib/Device/Gsm/Sms/Token/DA.pm
+++ b/lib/Device/Gsm/Sms/Token/DA.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::DA;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/DCS.pm
+++ b/lib/Device/Gsm/Sms/Token/DCS.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::DCS;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/DT.pm
+++ b/lib/Device/Gsm/Sms/Token/DT.pm
@@ -11,8 +11,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::DT;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/MR.pm
+++ b/lib/Device/Gsm/Sms/Token/MR.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::MR;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/OA.pm
+++ b/lib/Device/Gsm/Sms/Token/OA.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::OA;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/PDUTYPE.pm
+++ b/lib/Device/Gsm/Sms/Token/PDUTYPE.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::PDUTYPE;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/PID.pm
+++ b/lib/Device/Gsm/Sms/Token/PID.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::PID;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/SCA.pm
+++ b/lib/Device/Gsm/Sms/Token/SCA.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::SCA;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/SCTS.pm
+++ b/lib/Device/Gsm/Sms/Token/SCTS.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::SCTS;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/ST.pm
+++ b/lib/Device/Gsm/Sms/Token/ST.pm
@@ -51,8 +51,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::ST;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/UD.pm
+++ b/lib/Device/Gsm/Sms/Token/UD.pm
@@ -9,8 +9,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::UD;
 use integer;

--- a/lib/Device/Gsm/Sms/Token/UDH.pm
+++ b/lib/Device/Gsm/Sms/Token/UDH.pm
@@ -9,8 +9,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::UDH;
 use strict;

--- a/lib/Device/Gsm/Sms/Token/VP.pm
+++ b/lib/Device/Gsm/Sms/Token/VP.pm
@@ -8,8 +8,6 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Perl licensing terms for details.
-#
-# $Id$
 
 package Sms::Token::VP;
 use integer;

--- a/makedoc.sh
+++ b/makedoc.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
-#
-# $Id: makedoc.sh,v 1.4 2004-01-22 23:21:42 cosimo Exp $
-#
 
 #mv README README.old
 #pod2text Gsm.pm >README

--- a/t/01basic.t
+++ b/t/01basic.t
@@ -1,5 +1,3 @@
-# $Id: 01basic.t,v 1.1 2002-04-03 19:13:35 cosimo Exp $
-
 use Test;
 BEGIN { plan tests => 2 }
 END { ok(0) unless $loaded }

--- a/t/02info.t
+++ b/t/02info.t
@@ -1,5 +1,3 @@
-# $Id: 02info.t,v 1.2 2002-09-25 22:08:06 cosimo Exp $
-#
 # test connection with a gsm device on serial port
 #
 use Test;

--- a/t/05messages.t
+++ b/t/05messages.t
@@ -1,5 +1,3 @@
-# $Id: 05messages.t,v 1.2 2004-05-25 21:01:32 cosimix Exp $
-#
 # test sim card message reading functions
 #
 use Test::More;

--- a/t/06msgcodec.t
+++ b/t/06msgcodec.t
@@ -1,5 +1,3 @@
-# $Id: 06msgcodec.t,v 1.8 2006-08-12 08:57:19 cosimo Exp $
-#
 # test sim card message encoding/decoding functions 
 #
 use Test::More;

--- a/t/07tokens.t
+++ b/t/07tokens.t
@@ -1,5 +1,3 @@
-# $Id: 07tokens.t,v 1.2 2007-02-28 21:18:14 cosimo Exp $
-#
 # test new token engine for decoding/encoding sms messages 
 #
 use Test::More;

--- a/t/08storage.t
+++ b/t/08storage.t
@@ -1,5 +1,3 @@
-# $Id: 08storage.t,v 1.1 2006-07-23 15:47:58 cosimo Exp $
-#
 # test new token engine for decoding/encoding sms messages 
 #
 use Test::More;

--- a/t/20pdu.t
+++ b/t/20pdu.t
@@ -1,4 +1,3 @@
-# $Id: 20pdu.t,v 1.8 2007-02-28 21:18:14 cosimo Exp $
 # test pdu encoding/decoding functions for sms
 
 use Test::More;

--- a/t/25msgread.t
+++ b/t/25msgread.t
@@ -1,4 +1,3 @@
-# $Id: 25msgread.t,v 1.5 2004-09-15 21:12:50 cosimo Exp $
 # test pdu messages decoding
 
 use Test;

--- a/t/30gsmascii.t
+++ b/t/30gsmascii.t
@@ -1,4 +1,3 @@
-# $Id: 30gsmascii.t,v 1.3 2004-09-15 21:02:40 cosimo Exp $
 # test gsm <=> ascii charset conversions
 
 use Test::More;

--- a/t/30networks.t
+++ b/t/30networks.t
@@ -1,4 +1,3 @@
-# $Id: 30networks.t,v 1.2 2007-02-28 20:54:32 cosimo Exp $
 # test pdu encoding/decoding functions for sms
 
 use Test::More;

--- a/t/31_rt_57585.t
+++ b/t/31_rt_57585.t
@@ -1,4 +1,3 @@
-# $Id: 20pdu.t,v 1.8 2007-02-28 21:18:14 cosimo Exp $
 # test pdu encoding/decoding functions for sms
 
 use Test::More;


### PR DESCRIPTION
The project is now managed by Git, hence the Subversion `$Id$` tags are no longer necessary.  This PR splits up the updates into several commits in order to hopefully simplify code review.