### PR TITLE
Use use_ok() in basic test

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -1,11 +1,10 @@
 # $Id: 01basic.t,v 1.1 2002-04-03 19:13:35 cosimo Exp $
 
-use Test;
-BEGIN { plan tests => 2 }
-END { ok(0) unless $loaded }
-use Device::Gsm;
-$loaded = 1;
-ok(1);
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use_ok 'Device::Gsm';
 
 my $gsm = Device::Gsm->new();
-ok($gsm);
+ok $gsm;


### PR DESCRIPTION
The test `01basic.t` was `use`-ing the `Device::Gsm` module and checking if
it had been loaded via an `END` block, which made the code a bit complex.
This test was written in 2002 and it's likely that the `use_ok` function
didn't exist back then.  Using the new function simplifies the test
significantly.