### PR TITLE
Correct ascii to gsm lowercase i acute conversion

### DIFF
--- a/lib/Device/Gsm/Charset.pm
+++ b/lib/Device/Gsm/Charset.pm
@@ -422,7 +422,7 @@ use constant ESCAPE => 0x1B;
     -101,        #   234    ê lowercase e circumflex                  */
     -101,        #   235    ë lowercase e dieresis or umlaut          */
     7,           #   236    ì lowercase i grave                       */
-    -7,          #   237    í lowercase i acute                       */
+    7,           #   237    í lowercase i acute                       */
     -105,        #   238    î lowercase i circumflex                  */
     -105,        #   239    ï lowercase i dieresis or umlaut          */
     NPC7,        #   240    ð lowercase eth                           */


### PR DESCRIPTION
After comparing the conversion table for pduconv (the original link no
longer exists; the only copy I managed to find is here:
https://github.com/rdmeneze/SMSBox-PIC/blob/master/source/pdu_conv/pduconv.cpp)
I noticed that the lowercase i acute conversion didn't match that in
pduconv.  This change updates the value appropriately so that the
conversion tables now match again.