### PR TITLE
Add Travis-CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: perl
+
+perl:
+    - "5.20"
+    - 5.18
+    - 5.16
+    - 5.14
+    - 5.12
+    - "5.10"
+
+install:
+    - cpanm Device::Modem


### PR DESCRIPTION
This enables the tests for this module to run on the Travis-CI
(travis-ci.org) continuous integration system.