### PR TITLE
Use Device::Gsm version for D::G::Charset VERSION

### DIFF
--- a/lib/Device/Gsm/Charset.pm
+++ b/lib/Device/Gsm/Charset.pm
@@ -12,7 +12,7 @@
 # $Id$
 
 package Device::Gsm::Charset;
-$VERSION = substr q$Revision$, 0, 10;
+$VERSION = $Device::Gsm::VERSION;
 
 use strict;
 use constant NPC7   => 0x3F;


### PR DESCRIPTION
The version set in D::G::Charset used the Subversion `$Revision$` tag to
determine the version number.  Since the project is now hosted in Git, this
no longer makes sense.  The best thing to do is thus to tie D::G::Charset's
version number to that of Device::Gsm itself.