### PR TITLE
Revert "Correct ascii to gsm lowercase i acute conversion"

### DIFF
--- a/lib/Device/Gsm/Charset.pm
+++ b/lib/Device/Gsm/Charset.pm
@@ -422,7 +422,7 @@ use constant ESCAPE => 0x1B;
     -101,        #   234    ê lowercase e circumflex                  */
     -101,        #   235    ë lowercase e dieresis or umlaut          */
     7,           #   236    ì lowercase i grave                       */
-    7,           #   237    í lowercase i acute                       */
+    -7,          #   237    í lowercase i acute                       */
     -105,        #   238    î lowercase i circumflex                  */
     -105,        #   239    ï lowercase i dieresis or umlaut          */
     NPC7,        #   240    ð lowercase eth                           */


### PR DESCRIPTION
Reverts cosimo/perl5-device-gsm#9

This change broke one of the tests, t/30gsmascii.t on character 237 because the test suite handles two characters mapping into the same GSM character by using the negative values to somewhat bypass these tests.

I believe that the file referenced at https://github.com/rdmeneze/SMSBox-PIC/blob/master/source/pdu_conv/pduconv.cpp has an error for this character.  As noted in the comment:

    ISO-characters that don't have any correspondning character in the
    7-bit alphabet is replaced with the NPC7-character.  If there's
    a close match between the ISO-char and a 7-bit character (for example
    the letter i with a circumflex and the plain i-character) a substitution
    is done. These "close-matches" are marked in the lookup table by
    having its value negated.

However, that is not the case after this change was applied, because the "i acute" is not the same as the "i grave", I believe the "i acute" should be negated (as it was originally before this pull request).

So this pull request will revert that change.