### PR TITLE
Don't treat $^O darwin (MacOS) like Win32

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ WriteMakefile(
     'PREREQ_PM'     => {
         'Test::More'    => 0,
         'Device::Modem' => 1.47,
-        ( $^O =~ /Win/i
+        ( ( ($^O =~ /Win/i) && (! ($^O =~ /darwin/i)) )
             ? ( 'Win32::SerialPort' => 0 )
             : ( 'Device::SerialPort'=> 0 )
         )


### PR DESCRIPTION
This allows the module to install properly on MacOS. The Makefile was using $^O to determine if Win32::SerialPort was needed with a grep for case-insensitive "win" in $^O. This wrongly detected "darwin" (the $^O value for MacOS) as Windows.

There are a few ways this could have been done, this is just one possibility, but I believe it will do the right thing on Win.*, cygwin, and darwin now.