### PR TITLE
Fix failed tests due to logic error in t/08storage.t

### DIFF
--- a/t/08storage.t
+++ b/t/08storage.t
@@ -1,7 +1,7 @@
 # test new token engine for decoding/encoding sms messages 
 #
 use Test::More;
-BEGIN { plan tests => 8 };
+BEGIN { plan tests => 7 };
 use lib '../lib';
 use_ok('Device::Gsm');
 use_ok('Device::Gsm::Sms');
@@ -40,7 +40,7 @@ if( $port eq '' ) {
 
 NOTICE
 
-	skip( 'Serial port not set up!', 6 );
+	skip( 'Serial port not set up!', 5 );
 
 }
 
@@ -68,7 +68,7 @@ is(undef, $storage, 'storage when starting is undefined');
 
 my $has_cpms = $gsm->test_command('+CPMS');
 
-$gsm->storage('SM');
+$storage = $gsm->storage('SM');
 
 if($has_cpms)
 {
@@ -79,7 +79,7 @@ else
     is($storage, undef, 'storage not changed because phone does not support it');
 }
 
-$gsm->storage('ME');
+$storage = $gsm->storage('ME');
 
 if($has_cpms)
 {


### PR DESCRIPTION
This test failed when run with $ENV{DEV_GSM_PORT} defined and a real module connected.  There were a couple of logic errors - First, there were two cases where the return value of $obj->storage() should have been used but wasn't. The other error was that only 7 tests are executed with a module connected, but the test plan indicated 8 - I fixed this and adjusted the skip value to 5 from 6 when testing without a module connected, so those tests continue to pass as well.

I expect this to fail the TravisCI build because of the problems #16  corrects - if both this pull request and the one referenced are merged, this will be able to pass TravisCI properly.