### PR TITLE
Memoize command test

### DIFF
--- a/lib/Device/Gsm.pm
+++ b/lib/Device/Gsm.pm
@@ -1,6 +1,7 @@
 # Device::Gsm - a Perl class to interface GSM devices as AT modems
 # Copyright (C) 2002-2015 Cosimo Streppone, cosimo@cpan.org
 # Copyright (C) 2006-2015 Grzegorz Wozniak, wozniakg@gmail.com
+# Copyright (C) 2016 Joel Maslak, jmaslak@antelope.net
 #
 # This program is free software; you can redistribute it and/or modify
 # it only under the terms of Perl itself.


### PR DESCRIPTION
It's not actually using memoize, but it is caching the results of the test_command after it is executed once for a given session (each object has its' own cache, and the cache is cleared on connect() or disconnect()).  This isn't necessarily a complete replacement for the profiles "todo" in the POD, but I believe it probably is a better solution since it can adapt to whatever next week's new device is without having to push a new package.

Note that without pull request #16  merged this will not pass tests but it passes fine once the tests are corrected.