### PR TITLE
Use proper module name in read_messages example

### DIFF
--- a/examples/read_messages.pl
+++ b/examples/read_messages.pl
@@ -6,7 +6,7 @@
 use strict;
 use lib '../lib';
 use lib '../';
-use Gsm;
+use Device::Gsm;
 
 print "\nthis is read_messages.pl\n";
 print "\nTrying to read all messages you have on your SIM card...\n";


### PR DESCRIPTION
Very small change to read_messages.pl to make it execute properly.

Note that TravisCI will likely fail until #16 is merged.